### PR TITLE
chore: docker-compose.yml redis 컨테이너 생성

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3.1"
+
+services:
+  redis-container:
+    image: redis:alpine
+    ports:
+      - "6379:6379"
+    labels:
+      - "name=redis"
+      - "mode=standalone"
+    restart: always


### PR DESCRIPTION
issue: #50

<!--
✅ Resolve: #이슈번호 형태로 입력해 주세요.
ex) Resolve: #123
-->
## Linked Issues
- Resolve: #50

<!--
✅ 변경 사항을 자세히 알려주세요. (why -> what -> how)
-->
## Change Details
- 빌드 중 테스트 환경에서의 테스트컨테이너를 이용하기 위해선 redis 컨테이너가 띄워져 있어야 합니다.
- 이 때 쉽게 redis 컨테이너를 띄우기 위해 docker-compose.yml에 redis 컨테이너를 추가해 주었습니다.

<!--
✅ 추가로 전달할 내용이 있다면 적어주세요.
-->
## Comment
- redis-container 옆의 버튼을 눌러주시면 redis 컨테이너가 생성됩니다.
<img  alt="image" src="https://github.com/bone-stew/popmate-be/assets/62706048/90c188f1-68b3-4c43-8575-e32bd31af04d">

<!--
✅ 참고한 사이트가 있다면 공유해주세요.
-->
## References
- 

## ✔ Check List

- [x] 코드 포매팅은 확인하셨나요?
- [x] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
