### PR TITLE
fix: 예약자 관련 API 버그 수정

### DIFF
--- a/src/docs/asciidoc/reservation.adoc
+++ b/src/docs/asciidoc/reservation.adoc
@@ -27,6 +27,15 @@ include::{snippets}/reservation-wifi-controller-test/wifi_목록을_통해_예�
 include::{snippets}/reservation-wifi-controller-test/wifi_목록을_통해_예약_가능한_위치인지_확인한다/response-fields.adoc[]
 
 
+== 선착순 예약을 신청한다
+
+=== Request
+include::{snippets}/reservation-event-controller-test/선착순_예약을_신청한다/path-parameters.adoc[]
+include::{snippets}/reservation-event-controller-test/선착순_예약을_신청한다/request-fields.adoc[]
+
+=== Response
+include::{snippets}/reservation-event-controller-test/선착순_예약을_신청한다/response-fields.adoc[]
+
 == 나의 예약 목록을 조회한다
 
 === Request
@@ -42,6 +51,15 @@ include::{snippets}/reservation-information-controller-test/나의_예약_상세
 
 === Response
 include::{snippets}/reservation-information-controller-test/나의_예약_상세를_조회한다/response-fields.adoc[]
+
+
+== 예약을 취소한다
+
+=== Request
+include::{snippets}/reservation-event-controller-test/예약을_취소한다/path-parameters.adoc[]
+
+=== Response
+include::{snippets}/reservation-event-controller-test/예약을_취소한다/response-fields.adoc[]
 
 
 == 일일 예약 목록을 조회한다 (관리자)
@@ -65,7 +83,7 @@ include::{snippets}/reservation-information-controller-test/오늘의_예약_목
 include::{snippets}/reservation-information-controller-test/오늘의_예약_목록을_조회한다/response-fields.adoc[]
 
 
-== 예약 인원 수를 변경한다
+== 예약 인원 수를 변경한다 (관리자)
 
 === Request
 include::{snippets}/reservation-information-controller-test/예약_인원_수를_변경한다/path-parameters.adoc[]
@@ -76,7 +94,7 @@ include::{snippets}/reservation-information-controller-test/예약_인원_수를
 include::{snippets}/reservation-information-controller-test/예약_인원_수를_변경한다/response-fields.adoc[]
 
 
-== 예약을 중단한다
+== 예약을 중단한다 (관리자)
 
 === Request
 include::{snippets}/reservation-information-controller-test/예약을_중단한다/path-parameters.adoc[]
@@ -85,7 +103,7 @@ include::{snippets}/reservation-information-controller-test/예약을_중단한�
 include::{snippets}/reservation-information-controller-test/예약을_중단한다/response-fields.adoc[]
 
 
-== 예약을 재개한다
+== 예약을 재개한다 (관리자)
 
 === Request
 include::{snippets}/reservation-information-controller-test/예약을_재개한다/path-parameters.adoc[]
@@ -94,7 +112,7 @@ include::{snippets}/reservation-information-controller-test/예약을_재개한�
 include::{snippets}/reservation-information-controller-test/예약을_재개한다/response-fields.adoc[]
 
 
-== 예약자 입장 정보를 조회한다
+== 예약자 목록을 조회한다 (관리자)
 
 === Request
 include::{snippets}/reservation-information-controller-test/예약자_입장_정보를_조회한다/path-parameters.adoc[]
@@ -103,7 +121,7 @@ include::{snippets}/reservation-information-controller-test/예약자_입장_정
 include::{snippets}/reservation-information-controller-test/예약자_입장_정보를_조회한다/response-fields.adoc[]
 
 
-== 예약자를 입장 처리한다
+== 예약자를 입장 처리한다 (관리자)
 
 === Request
 include::{snippets}/reservation-event-controller-test/예약자를_입장_처리한다/path-parameters.adoc[]
@@ -112,11 +130,3 @@ include::{snippets}/reservation-event-controller-test/예약자를_입장_처리
 === Response
 include::{snippets}/reservation-event-controller-test/예약자를_입장_처리한다/response-fields.adoc[]
 
-
-== 예약을 취소한다
-
-=== Request
-include::{snippets}/reservation-event-controller-test/예약을_취소한다/path-parameters.adoc[]
-
-=== Response
-include::{snippets}/reservation-event-controller-test/예약을_취소한다/response-fields.adoc[]

--- a/src/docs/asciidoc/reservation.adoc
+++ b/src/docs/asciidoc/reservation.adoc
@@ -30,18 +30,18 @@ include::{snippets}/reservation-wifi-controller-test/wifi_목록을_통해_예�
 == 나의 예약 목록을 조회한다
 
 === Request
-include::{snippets}/reservation-information-controller-test/나의_예약_목록을_조회한다/http-request.adoc[]
+include::{snippets}/reservation-information-controller-test/나의_예약_상세를_조회한다/http-request.adoc[]
 
 === Response
-include::{snippets}/reservation-information-controller-test/나의_예약_목록을_조회한다/response-fields.adoc[]
+include::{snippets}/reservation-information-controller-test/나의_예약_상세를_조회한다/response-fields.adoc[]
 
 == 나의 예약 정보를 조회한다
 
 === Request
-include::{snippets}/reservation-information-controller-test/나의_예약_정보를_조회한다/path-parameters.adoc[]
+include::{snippets}/reservation-information-controller-test/나의_예약_상세를_조회한다/path-parameters.adoc[]
 
 === Response
-include::{snippets}/reservation-information-controller-test/나의_예약_정보를_조회한다/response-fields.adoc[]
+include::{snippets}/reservation-information-controller-test/나의_예약_상세를_조회한다/response-fields.adoc[]
 
 
 == 일일 예약 목록을 조회한다 (관리자)

--- a/src/docs/asciidoc/reservation.adoc
+++ b/src/docs/asciidoc/reservation.adoc
@@ -20,19 +20,28 @@ include::{snippets}/reservation-information-controller-test/진행_중인_예약
 == wifi 목록을 통해 예약 가능한 위치인지 확인한다
 
 === Request
+include::{snippets}/reservation-wifi-controller-test/wifi_목록을_통해_예약_가능한_위치인지_확인한다/http-request.adoc[]
 include::{snippets}/reservation-wifi-controller-test/wifi_목록을_통해_예약_가능한_위치인지_확인한다/request-fields.adoc[]
 
 === Response
 include::{snippets}/reservation-wifi-controller-test/wifi_목록을_통해_예약_가능한_위치인지_확인한다/response-fields.adoc[]
 
 
+== 나의 예약 목록을 조회한다
+
+=== Request
+include::{snippets}/reservation-information-controller-test/나의_예약_목록을_조회한다/http-request.adoc[]
+
+=== Response
+include::{snippets}/reservation-information-controller-test/나의_예약_목록을_조회한다/response-fields.adoc[]
+
 == 나의 예약 정보를 조회한다
 
 === Request
-include::{snippets}/reservation-information-controller-test/나의_예약_정보을_조회한다/path-parameters.adoc[]
+include::{snippets}/reservation-information-controller-test/나의_예약_정보를_조회한다/path-parameters.adoc[]
 
 === Response
-include::{snippets}/reservation-information-controller-test/나의_예약_정보을_조회한다/response-fields.adoc[]
+include::{snippets}/reservation-information-controller-test/나의_예약_정보를_조회한다/response-fields.adoc[]
 
 
 == 일일 예약 목록을 조회한다 (관리자)

--- a/src/main/java/com/bonestew/popmate/reservation/application/ReservationEventService.java
+++ b/src/main/java/com/bonestew/popmate/reservation/application/ReservationEventService.java
@@ -131,17 +131,13 @@ public class ReservationEventService {
     @Transactional
     public void cancel(Long reservationId, Long userId) {
         UserReservation userReservation = userReservationDao.findByReservationIdAndUserIdAndStatus(reservationId, userId, UserReservationStatus.RESERVED)
-            .orElseThrow(() -> new UserReservationNotFoundException(reservationId, userId));
+            .orElseThrow(() -> new UserReservationNotFoundException(reservationId));
 
         if (!userReservation.getStatus().isReserved()) {
             throw new InvalidReservationCancellationException(userReservation.getUserReservationId());
         }
-        System.out.println("userReservation = " + userReservation);
-        System.out.println("취소할 팀원들 = " + userReservation.getGuestCount());
-        System.out.println("기존 예약 시간대 사람들 = " + userReservation.getReservation().getCurrentGuestCount());
         userReservationDao.updateStatus(userReservation.getUserReservationId(), UserReservationStatus.CANCELED);
         userReservation.getReservation().decreaseCurrentGuestCount(userReservation.getGuestCount());
-        System.out.println("업데이트할 예약 시간대 사람들 = " + userReservation.getReservation().getCurrentGuestCount());
         reservationDao.updateCurrentGuestCount(reservationId, userReservation.getReservation().getCurrentGuestCount());
 
         log.info("Cancel successful for user ID: {}, reservation ID: {}", userId, reservationId);
@@ -157,7 +153,7 @@ public class ReservationEventService {
     public void processEntrance(Long reservationId, ProcessEntranceRequest processEntranceRequest) {
         Long userId = processEntranceRequest.reservationUserId();
         UserReservation userReservation = userReservationDao.findByReservationIdAndUserIdAndStatus(reservationId, userId, UserReservationStatus.RESERVED)
-            .orElseThrow(() -> new UserReservationNotFoundException(reservationId, userId));
+            .orElseThrow(() -> new UserReservationNotFoundException(reservationId));
 
         userReservation.validateEntry();
         userReservationDao.updateStatus(userReservation.getUserReservationId(), UserReservationStatus.VISITED);

--- a/src/main/java/com/bonestew/popmate/reservation/application/ReservationInformationService.java
+++ b/src/main/java/com/bonestew/popmate/reservation/application/ReservationInformationService.java
@@ -34,9 +34,9 @@ public class ReservationInformationService {
         return userReservationDao.getByUserId(userId);
     }
 
-    public UserReservation getMyReservation(Long reservationId, Long userId) {
-        return userReservationDao.findByReservationIdAndUserIdAndStatus(reservationId, userId, UserReservationStatus.RESERVED) // 추후 userReservationId로 찾을 수 있도록 수정이 필요
-            .orElseThrow(() -> new UserReservationNotFoundException(reservationId, userId));
+    public UserReservation getMyReservation(Long userReservationId) {
+        return userReservationDao.findById(userReservationId)
+            .orElseThrow(() -> new UserReservationNotFoundException(userReservationId));
     }
 
     public Reservation getCurrentlyEnteredReservation(Long popupStoreId) {

--- a/src/main/java/com/bonestew/popmate/reservation/exception/UserReservationNotFoundException.java
+++ b/src/main/java/com/bonestew/popmate/reservation/exception/UserReservationNotFoundException.java
@@ -4,7 +4,7 @@ import com.bonestew.popmate.exception.NotFoundException;
 
 public class UserReservationNotFoundException extends NotFoundException {
 
-    public UserReservationNotFoundException(Long userReservationId, Long userId) {
-        super("UserReservation not found. ReservationId: " + userReservationId + ", UserId: " + userId);
+    public UserReservationNotFoundException(Long userReservationId) {
+        super("UserReservation not found. UserReservationId: " + userReservationId);
     }
 }

--- a/src/main/java/com/bonestew/popmate/reservation/persistence/UserReservationDao.java
+++ b/src/main/java/com/bonestew/popmate/reservation/persistence/UserReservationDao.java
@@ -11,9 +11,9 @@ public interface UserReservationDao {
 
     void save(UserReservation userReservation);
 
-    boolean existsByUserIdAndReservationId(Long userId, Long reservationId, UserReservationStatus status);
+    Optional<UserReservation> findById(Long userReservationId);
 
-    Optional<UserReservation> findByReservationIdAndUserId(Long reservationId, Long userId);
+    boolean existsByUserIdAndReservationId(Long userId, Long reservationId, UserReservationStatus status);
 
     Optional<UserReservation> findByReservationIdAndUserIdAndStatus(Long reservationId,
                                                                     Long userId,

--- a/src/main/java/com/bonestew/popmate/reservation/presentation/ReservationEventController.java
+++ b/src/main/java/com/bonestew/popmate/reservation/presentation/ReservationEventController.java
@@ -67,7 +67,7 @@ public class ReservationEventController {
     }
 
     /**
-     * 추후 popupstore-api에서 호출 예정
+     * 개발 편의를 위한 예약 데이터 생성 API (팝업스토어 생성 API 에서 사용 중인 서비스 메서드)
      */
     @Deprecated
     @GetMapping("/reservations/test")

--- a/src/main/java/com/bonestew/popmate/reservation/presentation/ReservationEventController.java
+++ b/src/main/java/com/bonestew/popmate/reservation/presentation/ReservationEventController.java
@@ -6,6 +6,7 @@ import com.bonestew.popmate.reservation.application.ReservationEventService;
 import com.bonestew.popmate.reservation.application.dto.CreateReservationDto;
 import com.bonestew.popmate.reservation.application.dto.ProcessEntranceRequest;
 import com.bonestew.popmate.reservation.application.dto.ReservationRequest;
+import com.bonestew.popmate.reservation.presentation.dto.CreateUserReservationResponse;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -29,13 +30,16 @@ public class ReservationEventController {
      *
      * @param reservationId      예약 식별자
      * @param reservationRequest 예약 요청 정보
+     * @return 예약 신청 결과 (예약 성공했을 경우 예약자 식별자)
      */
     @PostMapping("/{reservationId}")
-    public ApiResponse<Void> reserve(@PathVariable("reservationId") final Long reservationId,
-                                     @RequestBody final ReservationRequest reservationRequest,
-                                     @AuthenticationPrincipal PopmateUser popmateUser) {
-        reservationEventService.reserve(reservationId, popmateUser.getUserId(), reservationRequest);
-        return ApiResponse.success();
+    public ApiResponse<CreateUserReservationResponse> reserve(@PathVariable("reservationId") final Long reservationId,
+                                                              @RequestBody final ReservationRequest reservationRequest,
+                                                              @AuthenticationPrincipal PopmateUser popmateUser) {
+        return ApiResponse.success(
+            new CreateUserReservationResponse(
+                reservationEventService.reserve(reservationId, popmateUser.getUserId(), reservationRequest))
+        );
     }
 
     /**

--- a/src/main/java/com/bonestew/popmate/reservation/presentation/ReservationEventController.java
+++ b/src/main/java/com/bonestew/popmate/reservation/presentation/ReservationEventController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/reservations")
+@RequestMapping("/api/v1")
 public class ReservationEventController {
 
     private final ReservationEventService reservationEventService;
@@ -32,7 +32,7 @@ public class ReservationEventController {
      * @param reservationRequest 예약 요청 정보
      * @return 예약 신청 결과 (예약 성공했을 경우 예약자 식별자)
      */
-    @PostMapping("/{reservationId}")
+    @PostMapping("/reservations/{reservationId}")
     public ApiResponse<CreateUserReservationResponse> reserve(@PathVariable("reservationId") final Long reservationId,
                                                               @RequestBody final ReservationRequest reservationRequest,
                                                               @AuthenticationPrincipal PopmateUser popmateUser) {
@@ -45,12 +45,11 @@ public class ReservationEventController {
     /**
      * 예약 취소
      *
-     * @param reservationId
+     * @param userReservationId 예약자 식별자
      */
-    @PatchMapping("/{reservationId}/cancel")
-    public ApiResponse<Void> cancelReservation(@PathVariable("reservationId") Long reservationId,
-                                               @AuthenticationPrincipal PopmateUser popmateUser) {
-        reservationEventService.cancel(reservationId, popmateUser.getUserId());
+    @PatchMapping("/user-reservations/{userReservationId}/cancel")
+    public ApiResponse<Void> cancelReservation(@PathVariable("userReservationId") final Long userReservationId) {
+        reservationEventService.cancel(userReservationId);
         return ApiResponse.success();
     }
 
@@ -60,7 +59,7 @@ public class ReservationEventController {
      * @param reservationId
      * @return 예약자 입장 처리 결과
      */
-    @PatchMapping("/{reservationId}/entrance")
+    @PatchMapping("/reservations/{reservationId}/entrance")
     public ApiResponse<Void> processEntrance(@PathVariable("reservationId") Long reservationId,
                                              @RequestBody ProcessEntranceRequest processEntranceRequest) {
         reservationEventService.processEntrance(reservationId, processEntranceRequest);
@@ -71,7 +70,7 @@ public class ReservationEventController {
      * 추후 popupstore-api에서 호출 예정
      */
     @Deprecated
-    @GetMapping("/test")
+    @GetMapping("/reservations/test")
     public void createReservation() {
         CreateReservationDto sampleReservationDto = new CreateReservationDto(
             20,

--- a/src/main/java/com/bonestew/popmate/reservation/presentation/ReservationInformationController.java
+++ b/src/main/java/com/bonestew/popmate/reservation/presentation/ReservationInformationController.java
@@ -46,7 +46,7 @@ public class ReservationInformationController {
     }
 
     /**
-     * 내가 예약한 목록 조회
+     * 나의 예약 목록 조회
      *
      * @return 예약 목록
      */

--- a/src/main/java/com/bonestew/popmate/reservation/presentation/ReservationInformationController.java
+++ b/src/main/java/com/bonestew/popmate/reservation/presentation/ReservationInformationController.java
@@ -4,7 +4,7 @@ import com.bonestew.popmate.auth.domain.PopmateUser;
 import com.bonestew.popmate.dto.ApiResponse;
 import com.bonestew.popmate.reservation.application.ReservationInformationService;
 import com.bonestew.popmate.reservation.application.dto.GuestLimitUpdateRequest;
-import com.bonestew.popmate.reservation.application.dto.ReservationEntranceResponse;
+import com.bonestew.popmate.reservation.presentation.dto.ReservationEntranceResponse;
 import com.bonestew.popmate.reservation.presentation.dto.MyReservationResponse;
 import com.bonestew.popmate.reservation.domain.UserReservation;
 import com.bonestew.popmate.reservation.presentation.dto.ActiveReservationResponse;
@@ -61,7 +61,7 @@ public class ReservationInformationController {
     /**
      * 나의 예약 상세 조회
      *
-     * @param userReservationId 사용자 예약 식별자
+     * @param userReservationId 예약지 식별자
      * @return 예약 정보
      */
     @GetMapping("/members/me/user-reservations/{userReservationId}")
@@ -90,7 +90,7 @@ public class ReservationInformationController {
     }
 
     /**
-     * 오늘의 예약 목록 조회 (관리자)
+     * 현재 입장 중인 예약 상세, 예약 목록 현황 조회 (관리자)
      *
      * @param popupStoreId 팝업스토어 식별자
      * @return 오늘의 예약 목록
@@ -140,7 +140,7 @@ public class ReservationInformationController {
     }
 
     /**
-     * 예약자 입장 정보 조회 (관리자)
+     * 예약자 목록 조회 (관리자)
      *
      * @param reservationId 예약 식별자
      * @return 예약 정보

--- a/src/main/java/com/bonestew/popmate/reservation/presentation/ReservationInformationController.java
+++ b/src/main/java/com/bonestew/popmate/reservation/presentation/ReservationInformationController.java
@@ -59,17 +59,16 @@ public class ReservationInformationController {
     }
 
     /**
-     * 나의 예약 상세 조회 (추후 reservations -> userReservation 으로 변경 필요)
+     * 나의 예약 상세 조회
      *
-     * @param reservationId 예약 식별자
+     * @param userReservationId 사용자 예약 식별자
      * @return 예약 정보
      */
-    @GetMapping("/members/me/reservations/{reservationId}")
-    public ApiResponse<MyReservationResponse> getReservation(@PathVariable("reservationId") Long reservationId,
-                                                             @AuthenticationPrincipal PopmateUser popmateUser) {
+    @GetMapping("/members/me/user-reservations/{userReservationId}")
+    public ApiResponse<MyReservationResponse> getUserReservation(@PathVariable("userReservationId") Long userReservationId) {
         return ApiResponse.success(
             MyReservationResponse.from(
-                reservationInformationService.getMyReservation(reservationId, popmateUser.getUserId())
+                reservationInformationService.getMyReservation(userReservationId)
             ));
     }
 

--- a/src/main/java/com/bonestew/popmate/reservation/presentation/dto/CreateUserReservationResponse.java
+++ b/src/main/java/com/bonestew/popmate/reservation/presentation/dto/CreateUserReservationResponse.java
@@ -1,0 +1,5 @@
+package com.bonestew.popmate.reservation.presentation.dto;
+
+public record CreateUserReservationResponse(Long userReservationId) {
+
+}

--- a/src/main/java/com/bonestew/popmate/reservation/presentation/dto/ReservationEntranceResponse.java
+++ b/src/main/java/com/bonestew/popmate/reservation/presentation/dto/ReservationEntranceResponse.java
@@ -1,4 +1,4 @@
-package com.bonestew.popmate.reservation.application.dto;
+package com.bonestew.popmate.reservation.presentation.dto;
 
 import com.bonestew.popmate.reservation.domain.UserReservation;
 import java.time.LocalDateTime;

--- a/src/main/java/com/bonestew/popmate/reservation/presentation/dto/ReservationResponse.java
+++ b/src/main/java/com/bonestew/popmate/reservation/presentation/dto/ReservationResponse.java
@@ -5,6 +5,7 @@ import com.bonestew.popmate.reservation.domain.UserReservationStatus;
 import java.time.LocalDateTime;
 
 public record ReservationResponse(
+    Long userReservationId,
     Long reservationId,
     String reservationStatus,
     LocalDateTime startTime,
@@ -16,6 +17,7 @@ public record ReservationResponse(
 
     public static ReservationResponse from(UserReservation userReservation) {
         return new ReservationResponse(
+            userReservation.getUserReservationId(),
             userReservation.getReservation().getReservationId(),
             userReservation.getStatus().getDescription(),
             userReservation.getReservation().getStartTime(),

--- a/src/main/resources/mapper/reservation/UserReservationMapper.xml
+++ b/src/main/resources/mapper/reservation/UserReservationMapper.xml
@@ -96,6 +96,9 @@
   </select>
 
   <insert id="save" parameterType="UserReservation">
+    <selectKey keyColumn="user_reservation_id" keyProperty="userReservationId" resultType="Long" order="AFTER">
+      select TB_USER_RESERVATION_SEQ.CURRVAL from dual
+    </selectKey>
     INSERT INTO tb_user_reservation (user_id, reservation_id, status, guest_count, qr_img_url)
     VALUES (#{user.userId}, #{reservation.reservationId}, #{status}, #{guestCount}, #{qrImgUrl})
   </insert>

--- a/src/main/resources/mapper/reservation/UserReservationMapper.xml
+++ b/src/main/resources/mapper/reservation/UserReservationMapper.xml
@@ -60,6 +60,14 @@
     <collection column="reservation_id" property="reservation" resultMap="reservationMap"/>
   </resultMap>
 
+  <select id="findById" parameterType="long" resultMap="userReservationMap">
+    SELECT *
+    FROM tb_user_reservation A
+           LEFT JOIN tb_reservation B ON A.reservation_id = B.reservation_id
+           LEFT JOIN tb_popup_store C ON B.popup_store_id = C.popup_store_id
+    WHERE A.user_reservation_id = #{userReservationId}
+  </select>
+
   <select id="findByReservationIdAndUserId" resultMap="userReservationMap">
     SELECT *
     FROM tb_user_reservation A

--- a/src/test/java/com/bonestew/popmate/reservation/presentation/ReservationEventControllerTest.java
+++ b/src/test/java/com/bonestew/popmate/reservation/presentation/ReservationEventControllerTest.java
@@ -117,7 +117,7 @@ class ReservationEventControllerTest {
                         .type(JsonFieldType.STRING),
                     fieldWithPath("message").description("응답 메시지")
                         .type(null),
-                    fieldWithPath("data.userReservationId").description("응답 데이터")
+                    fieldWithPath("data").description("응답 데이터")
                         .type(null)
                 )
             ));

--- a/src/test/java/com/bonestew/popmate/reservation/presentation/ReservationEventControllerTest.java
+++ b/src/test/java/com/bonestew/popmate/reservation/presentation/ReservationEventControllerTest.java
@@ -126,11 +126,11 @@ class ReservationEventControllerTest {
     @Test
     void 예약을_취소한다() throws Exception {
         // given
-        Long reservationId = 1L;
+        Long userReservationId= 1L;
 
         // when
         ResultActions result = mockMvc.perform(
-            patch("/api/v1/reservations/{reservationId}/cancel", reservationId)
+            patch("/api/v1/user-reservations/{userReservationId}/cancel", userReservationId)
                 .contentType(MediaType.APPLICATION_JSON));
 
         // then
@@ -138,7 +138,7 @@ class ReservationEventControllerTest {
             .andExpect(status().isOk())
             .andDo(customDocument(
                 pathParameters(
-                    parameterWithName("reservationId").description("예약 ID")
+                    parameterWithName("userReservationId").description("예약자 ID")
                 ),
                 responseFields(
                     fieldWithPath("code").description("응답 코드")

--- a/src/test/java/com/bonestew/popmate/reservation/presentation/ReservationEventControllerTest.java
+++ b/src/test/java/com/bonestew/popmate/reservation/presentation/ReservationEventControllerTest.java
@@ -3,6 +3,7 @@ package com.bonestew.popmate.reservation.presentation;
 import static com.bonestew.popmate.helper.RestDocsHelper.customDocument;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
@@ -12,8 +13,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.bonestew.popmate.reservation.application.ReservationEventService;
 import com.bonestew.popmate.reservation.application.dto.ProcessEntranceRequest;
+import com.bonestew.popmate.reservation.application.dto.ReservationRequest;
+import com.bonestew.popmate.reservation.application.dto.WifiInfoRequest;
 import com.bonestew.popmate.utils.WithMockCustomUser;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
@@ -39,6 +44,49 @@ class ReservationEventControllerTest {
 
     @Autowired
     private ObjectMapper objectMapper;
+
+    @Test
+    void 선착순_예약을_신청한다() throws Exception {
+        // given
+        Long reservationId = 1L;
+        Long userReservationId = 1L;
+        WifiInfoRequest wifiInfoRequest = new WifiInfoRequest("ssid", "bssid");
+        ReservationRequest reservationRequest = new ReservationRequest(2, List.of(wifiInfoRequest));
+
+        // when
+        given(reservationEventService.reserve(reservationId, 1L, reservationRequest))
+            .willReturn(userReservationId);
+
+        ResultActions result = mockMvc.perform(
+            post("/api/v1/reservations/{reservationId}", reservationId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(reservationRequest)));
+
+        // then
+        result
+            .andExpect(status().isOk())
+            .andDo(customDocument(
+                pathParameters(
+                    parameterWithName("reservationId").description("예약 ID")
+                ),
+                requestFields(
+                    fieldWithPath("guestCount").description("예약 인원 수")
+                        .type(JsonFieldType.NUMBER),
+                    fieldWithPath("wifiList[].ssid").description("와이파이 ssid")
+                        .type(JsonFieldType.STRING),
+                    fieldWithPath("wifiList[].bssid").description("와이파이 bssid")
+                        .type(JsonFieldType.STRING)
+                ),
+                responseFields(
+                    fieldWithPath("code").description("응답 코드")
+                        .type(JsonFieldType.STRING),
+                    fieldWithPath("message").description("응답 메시지")
+                        .type(null),
+                    fieldWithPath("data.userReservationId").description("응답 데이터")
+                        .type(JsonFieldType.NUMBER)
+                )
+            ));
+    }
 
     @Test
     void 예약자를_입장_처리한다() throws Exception {
@@ -69,7 +117,7 @@ class ReservationEventControllerTest {
                         .type(JsonFieldType.STRING),
                     fieldWithPath("message").description("응답 메시지")
                         .type(null),
-                    fieldWithPath("data").description("응답 데이터")
+                    fieldWithPath("data.userReservationId").description("응답 데이터")
                         .type(null)
                 )
             ));

--- a/src/test/java/com/bonestew/popmate/reservation/presentation/ReservationInformationControllerTest.java
+++ b/src/test/java/com/bonestew/popmate/reservation/presentation/ReservationInformationControllerTest.java
@@ -68,7 +68,8 @@ class ReservationInformationControllerTest {
         popupStoreId = 1L;
         dateTime = LocalDateTime.of(2023, 10, 1, 10, 0);
         date = LocalDate.of(2023, 10, 1);
-        popupStore = new PopupStore(1L, new User(), new Department(), new ChatRoom(), new Category(),"Your Title", "Your Organizer",
+        popupStore = new PopupStore(1L, new User(), new Department(), new ChatRoom(), new Category(), "Your Title",
+            "Your Organizer",
             "Your Place Detail", "Your Description", "Your Event Description", "Your Banner Image URL", 100, 200, true,
             true,
             15, 5, 10, dateTime, dateTime.plusDays(14), dateTime, dateTime.plusHours(8), 0L, dateTime, 0);
@@ -104,6 +105,98 @@ class ReservationInformationControllerTest {
                     fieldWithPath("data.popupStoreDescription").description("팝업스토어 설명"),
                     fieldWithPath("data.popupStoreOpenTime").description("팝업스토어 오픈 시간"),
                     fieldWithPath("data.popupStoreCloseTime").description("팝업스토어 종료 시간")
+                )
+            ));
+    }
+
+    @Test
+    void 나의_예약_목록을_조회한다() throws Exception {
+        // given
+        Long userId = 1L;
+        Reservation reservation = new Reservation(1L, popupStore, 10, 5, 50, 30, ReservationStatus.IN_PROGRESS,
+            dateTime, dateTime.plusMinutes(15), dateTime.plusMinutes(30), dateTime.plusMinutes(45), dateTime);
+        UserReservation userReservation = new UserReservation(1L, new User(), reservation, 2, "qrImgUrl",
+            UserReservationStatus.RESERVED, dateTime);
+        UserReservation userReservation2 = new UserReservation(1L, new User(), reservation, 2, "qrImgUrl",
+            UserReservationStatus.VISITED, dateTime);
+        UserReservation userReservation3 = new UserReservation(1L, new User(), reservation, 2, "qrImgUrl",
+            UserReservationStatus.CANCELED, dateTime);
+
+        // when
+        given(reservationInformationService.getMyReservations(userId)).willReturn(List.of(userReservation, userReservation2, userReservation3));
+
+        ResultActions result = mockMvc.perform(
+            get("/api/v1/members/me/reservations"));
+
+        // then
+        result
+            .andExpect(status().isOk())
+            .andDo(customDocument(
+                responseFields(
+                    fieldWithPath("code").description("응답 코드"),
+                    fieldWithPath("message").description("응답 메시지"),
+                    fieldWithPath("data.before[].userReservationId").description("예약자 정보 ID"),
+                    fieldWithPath("data.before[].reservationId").description("예약 ID"),
+                    fieldWithPath("data.before[].reservationStatus").description("예약 상태"),
+                    fieldWithPath("data.before[].startTime").description("예약 시작 시간"),
+                    fieldWithPath("data.before[].endTime").description("예약 종료 시간"),
+                    fieldWithPath("data.before[].popupStoreId").description("팝업스토어 ID"),
+                    fieldWithPath("data.before[].popupStoreTitle").description("팝업스토어 제목"),
+                    fieldWithPath("data.before[].bannerImgUrl").description("팝업스토어 배너 이미지 URL"),
+                    fieldWithPath("data.after[].userReservationId").description("예약자 정보 ID"),
+                    fieldWithPath("data.after[].reservationId").description("예약 ID"),
+                    fieldWithPath("data.after[].reservationStatus").description("예약 상태"),
+                    fieldWithPath("data.after[].startTime").description("예약 시작 시간"),
+                    fieldWithPath("data.after[].endTime").description("예약 종료 시간"),
+                    fieldWithPath("data.after[].popupStoreId").description("팝업스토어 ID"),
+                    fieldWithPath("data.after[].popupStoreTitle").description("팝업스토어 제목"),
+                    fieldWithPath("data.after[].bannerImgUrl").description("팝업스토어 배너 이미지 URL"),
+                    fieldWithPath("data.canceled[].userReservationId").description("예약자 정보 ID"),
+                    fieldWithPath("data.canceled[].reservationId").description("예약 ID"),
+                    fieldWithPath("data.canceled[].reservationStatus").description("예약 상태"),
+                    fieldWithPath("data.canceled[].startTime").description("예약 시작 시간"),
+                    fieldWithPath("data.canceled[].endTime").description("예약 종료 시간"),
+                    fieldWithPath("data.canceled[].popupStoreId").description("팝업스토어 ID"),
+                    fieldWithPath("data.canceled[].popupStoreTitle").description("팝업스토어 제목"),
+                    fieldWithPath("data.canceled[].bannerImgUrl").description("팝업스토어 배너 이미지 URL")
+                )
+            ));
+    }
+
+    @Test
+    void 나의_예약_정보를_조회한다() throws Exception {
+        // given
+        Long reservationId = 1L;
+        Long userId = 1L;
+        Reservation reservation = new Reservation(1L, popupStore, 10, 5, 50, 30, ReservationStatus.IN_PROGRESS,
+            dateTime, dateTime.plusMinutes(15), dateTime.plusMinutes(30), dateTime.plusMinutes(45), dateTime);
+        UserReservation userReservation = new UserReservation(1L, new User(), reservation, 2, "qrImgUrl",
+            UserReservationStatus.RESERVED, dateTime);
+
+        // when
+        given(reservationInformationService.getMyReservation(reservationId, userId)).willReturn(userReservation);
+
+        ResultActions result = mockMvc.perform(
+            get("/api/v1/members/me/reservations/{reservationId}", reservationId));
+
+        // then
+        result
+            .andExpect(status().isOk())
+            .andDo(customDocument(
+                pathParameters(
+                    parameterWithName("reservationId").description("조회할 예약 id")
+                ),
+                responseFields(
+                    fieldWithPath("code").description("응답 코드"),
+                    fieldWithPath("message").description("응답 메시지"),
+                    fieldWithPath("data.popupStoreTitle").description("팝업 스토어 제목"),
+                    fieldWithPath("data.popupStoreImageUrl").description("팝업 스토어 이미지 URL"),
+                    fieldWithPath("data.popupStorePlaceDetail").description("팝업 스토어 장소 상세 정보"),
+                    fieldWithPath("data.reservationQrImageUrl").description("예약 QR 코드 이미지 URL"),
+                    fieldWithPath("data.guestCount").description("예약 인원 수"),
+                    fieldWithPath("data.visitStartTime").description("입장 시작 시간"),
+                    fieldWithPath("data.visitEndTime").description("입장 종료 시간"),
+                    fieldWithPath("data.reservationStatus").description("예약 상태 (예: PENDING)")
                 )
             ));
     }
@@ -147,44 +240,6 @@ class ReservationInformationControllerTest {
                 )
             ));
 
-    }
-
-    @Test
-    void 나의_예약_정보을_조회한다() throws Exception {
-        // given
-        Long reservationId = 1L;
-        Long userId = 1L;
-        Reservation reservation = new Reservation(1L, popupStore, 10, 5, 50, 30, ReservationStatus.IN_PROGRESS,
-            dateTime, dateTime.plusMinutes(15), dateTime.plusMinutes(30), dateTime.plusMinutes(45), dateTime);
-        UserReservation userReservation = new UserReservation(1L, new User(), reservation, 2, "qrImgUrl",
-            UserReservationStatus.RESERVED, dateTime);
-
-        // when
-        given(reservationInformationService.getMyReservation(reservationId, userId)).willReturn(userReservation);
-
-        ResultActions result = mockMvc.perform(
-            get("/api/v1/members/me/reservations/{reservationId}", reservationId));
-
-        // then
-        result
-            .andExpect(status().isOk())
-            .andDo(customDocument(
-                pathParameters(
-                    parameterWithName("reservationId").description("조회할 예약 id")
-                ),
-                responseFields(
-                    fieldWithPath("code").description("응답 코드"),
-                    fieldWithPath("message").description("응답 메시지"),
-                    fieldWithPath("data.popupStoreTitle").description("팝업 스토어 제목"),
-                    fieldWithPath("data.popupStoreImageUrl").description("팝업 스토어 이미지 URL"),
-                    fieldWithPath("data.popupStorePlaceDetail").description("팝업 스토어 장소 상세 정보"),
-                    fieldWithPath("data.reservationQrImageUrl").description("예약 QR 코드 이미지 URL"),
-                    fieldWithPath("data.guestCount").description("예약 인원 수"),
-                    fieldWithPath("data.visitStartTime").description("입장 시작 시간"),
-                    fieldWithPath("data.visitEndTime").description("입장 종료 시간"),
-                    fieldWithPath("data.reservationStatus").description("예약 상태 (예: PENDING)")
-                )
-            ));
     }
 
     @Test

--- a/src/test/java/com/bonestew/popmate/reservation/presentation/ReservationInformationControllerTest.java
+++ b/src/test/java/com/bonestew/popmate/reservation/presentation/ReservationInformationControllerTest.java
@@ -164,27 +164,26 @@ class ReservationInformationControllerTest {
     }
 
     @Test
-    void 나의_예약_정보를_조회한다() throws Exception {
+    void 나의_예약_상세를_조회한다() throws Exception {
         // given
-        Long reservationId = 1L;
-        Long userId = 1L;
+        Long userReservationId = 1L;
         Reservation reservation = new Reservation(1L, popupStore, 10, 5, 50, 30, ReservationStatus.IN_PROGRESS,
             dateTime, dateTime.plusMinutes(15), dateTime.plusMinutes(30), dateTime.plusMinutes(45), dateTime);
         UserReservation userReservation = new UserReservation(1L, new User(), reservation, 2, "qrImgUrl",
             UserReservationStatus.RESERVED, dateTime);
 
         // when
-        given(reservationInformationService.getMyReservation(reservationId, userId)).willReturn(userReservation);
+        given(reservationInformationService.getMyReservation(userReservationId)).willReturn(userReservation);
 
         ResultActions result = mockMvc.perform(
-            get("/api/v1/members/me/reservations/{reservationId}", reservationId));
+            get("/api/v1/members/me/user-reservations/{userReservationId}", userReservationId));
 
         // then
         result
             .andExpect(status().isOk())
             .andDo(customDocument(
                 pathParameters(
-                    parameterWithName("reservationId").description("조회할 예약 id")
+                    parameterWithName("userReservationId").description("조회할 사용자 예약 id")
                 ),
                 responseFields(
                     fieldWithPath("code").description("응답 코드"),


### PR DESCRIPTION
<!--
✅ Resolve: #이슈번호 형태로 입력해 주세요.
ex) Resolve: #123
-->
## Linked Issues
- Resolve: #194 

<!-- ✅ 변경 사항을 자세히 알려주세요. -->
## Change Details
- 기존 userId, reservationId로 userReservationId를 조회하는 API를 모두 수정하였습니다.

변경된 API는 다음과 같습니다.
- 나의 예약 목록 조회
- 나의 예약 상세 조회
- 선착순 예약 신청
- 예약 취소

```json
// 나의 예약 목록 조회
{
  "code": "SUCCESS",
  "message": "성공",
  "data": {
    "before": [
      {
        "userReservationId": 1277, // 추가
        "reservationId": 2887,
        "reservationStatus": "예약 완료",
        "startTime": "2023-09-21T18:00:00",
        "endTime": "2023-09-21T18:20:00",
        "popupStoreId": 8,
        "popupStoreTitle": "레드팝",
        "bannerImgUrl": "https://popmate-bucket.s3.ap-northeast-2.amazonaws.com/store_imgs/f5cf02c1-6b75-41f6-aa21-1ebeb697dfa4-red.png"
      }
  ]
  "after": [],
  "cancel": []
}

// 선착순 예약 신청
{
  "code": "SUCCESS",
  "message": "성공",
  "data": {
    "userReservationId": 1364 // 추가
  }
}
```

```java
// 나의 예약 상세 조회 API

/members/me/reservations/{reservationId} ->
/members/me/user-reservations/{userReservationId}

// 예약 취소

/reservations/{reservationId}/cancel ->
/user-reservations/{userReservationId}/cancel
```

## ✔ Check List

- [x] 코드 포매팅은 확인하셨나요?
- [x] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
