### PR TITLE
feat: 스토어 순위, 매출, 예약 횟수 통계 자료 API

### DIFF
--- a/src/main/java/com/bonestew/popmate/chart/application/ChartService.java
+++ b/src/main/java/com/bonestew/popmate/chart/application/ChartService.java
@@ -1,0 +1,28 @@
+package com.bonestew.popmate.chart.application;
+
+import com.bonestew.popmate.chart.domain.ChartData;
+import com.bonestew.popmate.chart.domain.PopupStoreRank;
+import com.bonestew.popmate.chart.domain.ReservationCount;
+import com.bonestew.popmate.chart.domain.StoreRevenue;
+import com.bonestew.popmate.chart.persistence.ChartDao;
+import com.bonestew.popmate.chart.presentation.dto.ChartResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChartService {
+
+    private final ChartDao chartDao;
+
+    public ChartResponse getStatistics() {
+        ChartData data = new ChartData();
+        chartDao.loadChartData(data);
+        return new ChartResponse(data.getPopupStoreRanks(), data.getReservationCounts(), data.getStoreRevenues());
+    }
+
+}

--- a/src/main/java/com/bonestew/popmate/chart/domain/ChartData.java
+++ b/src/main/java/com/bonestew/popmate/chart/domain/ChartData.java
@@ -1,0 +1,15 @@
+package com.bonestew.popmate.chart.domain;
+
+import lombok.Data;
+import lombok.ToString;
+
+import java.util.List;
+
+@Data
+@ToString
+public class ChartData {
+
+    List<PopupStoreRank> popupStoreRanks;
+    List<ReservationCount> reservationCounts;
+    List<StoreRevenue> storeRevenues;
+}

--- a/src/main/java/com/bonestew/popmate/chart/domain/PopupStoreRank.java
+++ b/src/main/java/com/bonestew/popmate/chart/domain/PopupStoreRank.java
@@ -1,0 +1,11 @@
+package com.bonestew.popmate.chart.domain;
+
+import lombok.Data;
+import lombok.ToString;
+
+@Data
+@ToString
+public class PopupStoreRank {
+    private Long popupStoreId;
+    private String title;
+}

--- a/src/main/java/com/bonestew/popmate/chart/domain/ReservationCount.java
+++ b/src/main/java/com/bonestew/popmate/chart/domain/ReservationCount.java
@@ -1,0 +1,13 @@
+package com.bonestew.popmate.chart.domain;
+
+import lombok.Data;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Data
+@ToString
+public class ReservationCount {
+    private LocalDateTime time;
+    private Integer count;
+}

--- a/src/main/java/com/bonestew/popmate/chart/domain/StoreRevenue.java
+++ b/src/main/java/com/bonestew/popmate/chart/domain/StoreRevenue.java
@@ -1,0 +1,13 @@
+package com.bonestew.popmate.chart.domain;
+
+import lombok.Data;
+import lombok.ToString;
+
+@Data
+@ToString
+public class StoreRevenue {
+
+    private Long popupStoreId;
+    private String title;
+    private Integer revenue;
+}

--- a/src/main/java/com/bonestew/popmate/chart/persistence/ChartDao.java
+++ b/src/main/java/com/bonestew/popmate/chart/persistence/ChartDao.java
@@ -1,0 +1,9 @@
+package com.bonestew.popmate.chart.persistence;
+
+import com.bonestew.popmate.chart.domain.ChartData;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface ChartDao {
+    void loadChartData(ChartData data);
+}

--- a/src/main/java/com/bonestew/popmate/chart/presentation/ChartController.java
+++ b/src/main/java/com/bonestew/popmate/chart/presentation/ChartController.java
@@ -1,0 +1,28 @@
+package com.bonestew.popmate.chart.presentation;
+
+
+import com.bonestew.popmate.chart.application.ChartService;
+import com.bonestew.popmate.chart.presentation.dto.ChartResponse;
+import com.bonestew.popmate.dto.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/chart")
+public class ChartController {
+
+    private final ChartService chartService;
+
+    @GetMapping
+//    @Secured({"ROLE_MANAGER"})
+    public ApiResponse<ChartResponse> chart() {
+        return ApiResponse.success(chartService.getStatistics());
+    }
+
+}

--- a/src/main/java/com/bonestew/popmate/chart/presentation/dto/ChartResponse.java
+++ b/src/main/java/com/bonestew/popmate/chart/presentation/dto/ChartResponse.java
@@ -1,0 +1,14 @@
+package com.bonestew.popmate.chart.presentation.dto;
+
+import com.bonestew.popmate.chart.domain.PopupStoreRank;
+import com.bonestew.popmate.chart.domain.ReservationCount;
+import com.bonestew.popmate.chart.domain.StoreRevenue;
+
+import java.util.List;
+
+public record ChartResponse(
+        List<PopupStoreRank> popupStoreRanks,
+        List<ReservationCount> reservationCounts,
+        List<StoreRevenue> storeRevenues
+) {
+}

--- a/src/main/resources/mapper/chart/ChartMapper.xml
+++ b/src/main/resources/mapper/chart/ChartMapper.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.bonestew.popmate.chart.persistence.ChartDao">
+    <resultMap id="StoreRevenue" type="com.bonestew.popmate.chart.domain.StoreRevenue" />
+    <resultMap id="ReservationCount" type="com.bonestew.popmate.chart.domain.ReservationCount" />
+    <resultMap id="PopupStoreRank" type="com.bonestew.popmate.chart.domain.PopupStoreRank" />
+
+    <select id="loadChartData" statementType="CALLABLE">
+        {
+            CALL load_popmate_statistic(
+                #{storeRevenues, mode=OUT, jdbcType=CURSOR, javaType=java.sql.ResultSet, resultMap=StoreRevenue},
+                #{reservationCounts, mode=OUT, jdbcType=CURSOR, javaType=java.sql.ResultSet, resultMap=ReservationCount},
+                #{popupStoreRanks, mode=OUT, jdbcType=CURSOR, javaType=java.sql.ResultSet, resultMap=PopupStoreRank}
+            )
+        }
+    </select>
+</mapper>


### PR DESCRIPTION
<!--
✅ Resolve: #이슈번호 형태로 입력해 주세요.
ex) Resolve: #123
-->
## Linked Issues
- resolve #199 

<!-- ✅ 변경 사항을 자세히 알려주세요. -->
## Change Details
- 테이블 3곳에서 각 select를 해야 해서 한번 procedure를 활용해 보았습니다.
- 통계 페이지를 위한 API를 만들기 위해 Package를 추가 했습니다.
- 최근 1달 스토어별 매출, 요일별 예약 인원 수, 조회수 top 5 스토어를 반환합니다.

<!-- ✅ 추가로 전달할 내용이 있다면 적어주세요. -->
## Comment
- 각각 만드려다가 한 페이지에서만 쓰일거 같아서 한번 한번에 만들어 봤습니다.
- 최근 1달 스토어별 매출은 매출이 없는 경우 반환하지 않습니다.
- 원래 기획은 시간별 에약 인원 수이지만 아직 data가 저장되는거 같지 않아 요일별로 변경했습니다.

## ✔ Check List

- [x] 코드 포매팅은 확인하셨나요?
- [x] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
